### PR TITLE
Ruby 2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.4.0
-before_install: gem install bundler -v 1.13.7
+  - 2.4.3
+  - 2.5.0
+before_install: gem install bundler

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ In Ruby, local variable scope can be nested, and identification on local variabl
 This utility give labels to identify local variables.
 
 ```rb
+require "parser/current"
 require "ast_utils"
 
 node = Parser::CurrentRuby.parse(source)
@@ -39,6 +40,7 @@ labeled = ASTUtils::Labeling.translate(node: node)
 `AST` has `children` but no pointer to its parent.
 
 ```rb
+require "parser/current"
 require "ast_utils"
 
 node = Parser::CurrentRuby.parse(source)
@@ -54,6 +56,7 @@ parent = navigation.parent(child_node)
 It associates outer scope and its inner scope.
 
 ```rb
+require "parser/current"
 require "ast_utils"
 
 node = Parser::CurrentRuby.parse(source)

--- a/ast_utils.gemspec
+++ b/ast_utils.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest", "~> 5.0"
 
   spec.add_runtime_dependency "parser", "~> 2.4"
-  spec.add_runtime_dependency "thor", "~> 0.19.4"
+  spec.add_runtime_dependency "thor", "~> 0.19"
 end

--- a/exe/ast_utils
+++ b/exe/ast_utils
@@ -1,6 +1,10 @@
 #!/usr/bin/env ruby
 
 $LOAD_PATH << File.join(__dir__, "../lib")
+require "parser/ruby25"
+Parser::Builders::Default.emit_lambda = true
+Parser::Builders::Default.emit_procarg0 = true
+
 require "ast_utils"
 require "ast_utils/cli"
 

--- a/lib/ast_utils.rb
+++ b/lib/ast_utils.rb
@@ -1,6 +1,5 @@
 require "ast_utils/version"
 
-require "parser/current"
 require "pathname"
 require "set"
 
@@ -10,6 +9,3 @@ require "ast_utils/partial_map"
 require "ast_utils/labeling"
 require "ast_utils/navigation"
 require "ast_utils/scope"
-
-Parser::Builders::Default.emit_lambda = true
-Parser::Builders::Default.emit_procarg0 = true

--- a/lib/ast_utils/cli.rb
+++ b/lib/ast_utils/cli.rb
@@ -6,7 +6,7 @@ module ASTUtils
     def label(*scripts)
       scripts.map {|script| Pathname(script) }.each do |path|
         puts "Parsing #{path}..."
-        node = Parser::CurrentRuby.parse(path.read, path.to_s)
+        node = Parser::Ruby25.parse(path.read, path.to_s)
         puts "Translating node..."
         labeled = Labeling.translate(node: node)
         puts "#{labeled.inspect}"

--- a/test/labeling_test.rb
+++ b/test/labeling_test.rb
@@ -6,7 +6,7 @@ class LabelingTest < Minitest::Test
   include TestHelper
 
   def parse(source)
-    Parser::CurrentRuby.parse(source)
+    Parser::Ruby25.parse(source)
   end
 
   def test_lvar

--- a/test/navigation_test.rb
+++ b/test/navigation_test.rb
@@ -4,7 +4,7 @@ class NavigationTest < Minitest::Test
   include ASTUtils::NodeHelper
 
   def parse(source)
-    Parser::CurrentRuby.parse(source)
+    Parser::Ruby25.parse(source)
   end
 
   def test_parents

--- a/test/node_set_test.rb
+++ b/test/node_set_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class NodeSetTest < Minitest::Test
   def parse(source)
-    Parser::CurrentRuby.parse(source)
+    Parser::Ruby25.parse(source)
   end
 
   def test_set

--- a/test/scope_test.rb
+++ b/test/scope_test.rb
@@ -4,7 +4,7 @@ class ScopeTest < Minitest::Test
   include TestHelper
 
   def parse(source)
-    ASTUtils::Labeling.translate(node: Parser::CurrentRuby.parse(source))
+    ASTUtils::Labeling.translate(node: Parser::Ruby25.parse(source))
   end
 
   def test_scope

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,9 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+
+require "parser/ruby25"
+Parser::Builders::Default.emit_lambda = true
+Parser::Builders::Default.emit_procarg0 = true
+
 require 'ast_utils'
 
 require 'minitest/autorun'


### PR DESCRIPTION
* Update dependency to `parser` gem, `2.5` can be used now
* Does not require parser gem by itself (The client apps have to `require` parser library, like `require 'parser/current'` or `require 'parser/ruby25'`.)